### PR TITLE
Set nan values to zero in the normalized data.

### DIFF
--- a/bmxreduce/reduce_init.py
+++ b/bmxreduce/reduce_init.py
@@ -401,7 +401,7 @@ class reduce(object):
             v[~np.isfinite(v)] = 0
             norm[~np.isfinite(norm)] = np.inf
             rat = v/norm
-            rat[~np.isfinite(rat)]
+            rat[~np.isfinite(rat)] = 0
 
 
             # SVD decomp


### PR DESCRIPTION
NaN values in the array will cause error during computing svd.